### PR TITLE
Add /logout

### DIFF
--- a/src/Views/Login.vue
+++ b/src/Views/Login.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="container">
-    <LoginForm />
+    <LoginForm :bounceto="bounceto" />
   </div>
 </template>
 
@@ -11,6 +11,19 @@ export default {
   name: 'LoginPage',
   components: {
     LoginForm
+  },
+  props: {
+    bounceto: {
+      type: String,
+      default: '/'
+    }
+  },
+  // this blindly assumes that having *an* auth token means a user is logged in.
+  // if the auth token isn't valid, it will log them out after the api returns 401.
+  created: function () {
+    if (localStorage.getItem('auth') !== null) {
+      this.$router.push(this.bounceto)
+    }
   }
 }
 </script>

--- a/src/Views/Logout.vue
+++ b/src/Views/Logout.vue
@@ -1,0 +1,19 @@
+<script>
+export default {
+  name: 'LogoutPage',
+  props: {
+    bounceto: {
+      type: String,
+      default: '/'
+    }
+  },
+  created: function () {
+    localStorage.removeItem('auth')
+    this.$router.push(this.bounceto)
+  },
+  // we don't actually want to render anything. this is essentially a redirect.
+  render: function () {
+    return ''
+  }
+}
+</script>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -45,7 +45,7 @@ export default {
     },
     bounceto: {
       type: String,
-      default: ''
+      default: '/'
     }
   },
   data () {
@@ -69,7 +69,7 @@ export default {
           }
           this.errorMessage = ''
           localStorage.setItem('auth', response.data.bearer)
-          this.$router.push(this.bounceto || '/')
+          this.$router.push(this.bounceto)
         })
         .catch(error => {
           if (error.response && error.response.status === 401) {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import VueResource from 'vue-resource'
 import VueRouter from 'vue-router'
 import HomePage from './Views/Home.vue'
 import LoginPage from './Views/Login.vue'
+import LogoutPage from './Views/Logout.vue'
 import Register from './Views/Register.vue'
 
 Vue.use(VueI18n)
@@ -15,6 +16,7 @@ Vue.config.productionTip = false
 const routes = [
   { path: '/', component: HomePage, name: 'home' },
   { path: '/login', component: LoginPage, name: 'login' },
+  { path: '/logout', component: LogoutPage, name: 'logout' },
   { path: '/register', component: Register, name: 'register' }
 ]
 


### PR DESCRIPTION
As there's no session table on the back end this is a vue-only change.
It also changes /login to skip the flow if an auth token is present.
Dealing with auth tokens that aren't valid JWTs is handled in #34.

Currently logout will redirect a user to /, which redirects to the login
page. That should change, but as it stands the logout logic won't need
to when it does.

Closes #33