### PR TITLE
Run docker-compose stop, not down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ run:
 build:
 	docker build -t exlibris:latest .
 run-local:
-	docker-compose -f docker-compose.local.yml down
+	docker-compose -f docker-compose.local.yml stop
 	docker-compose -f docker-compose.local.yml up -d
 	npm install
 	go get github.com/githubnemo/CompileDaemon
 	set -a && source app.env && CompileDaemon -build='go build -o exlibris' -directory=. -command=./exlibris &
 	set -a && source .env && npm run serve
 dev:
-	docker-compose -f docker-compose.dev.yml down
+	docker-compose -f docker-compose.dev.yml stop
 	docker-compose -f docker-compose.dev.yml up --build


### PR DESCRIPTION
`down` will remove all volumes and containers, while `stop` just stops
them.

Fixes #38.